### PR TITLE
Fix segfault on empty path

### DIFF
--- a/pkg/vault-mon/pki.go
+++ b/pkg/vault-mon/pki.go
@@ -125,6 +125,11 @@ func (pki *PKI) loadCerts() error {
 	if err != nil {
 		return err
 	}
+	if secret == nil {
+		// if path has no certs, exit straight away
+		// before hitting a segfault
+		return nil
+	}
 
 	serialsList := vault.SecretList{}
 	err = mapstructure.Decode(secret.Data, &serialsList)


### PR DESCRIPTION
If `/pki/certs` return `nil`, previously the program would exit with a segfault. This ensure that we don't continue if `secret` is nil.