### PR TITLE
fix: properly handle cert revocation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 vendor/
 build/
 vault-pki-exporter
+
+# venom logs
+venom*log

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 vendor/
 build/
+vault-pki-exporter

--- a/compose.yaml
+++ b/compose.yaml
@@ -9,13 +9,18 @@ services:
     ports:
       - 8200:8200
     environment:
-      - VAULT_ADDR=http://vault:8200
+      - VAULT_ADDR=http://127.0.0.1:8200
       - VAULT_DEV_ROOT_TOKEN_ID=thisisatokenvalue
+      - VAULT_LISTEN_ADDRESS="0.0.0.0:8200"
+      - VAULT_ADDRESS="0.0.0.0:8200"
     healthcheck:
       test: vault status
       interval: 2s
       retries: 5
       timeout: 5s
+    volumes:
+      - ./vault-setup.sh:/vault-setup.sh
+    entrypoint: "sh vault-setup.sh"
   vault-pki-exporter:
     build:
       dockerfile: Dockerfile

--- a/compose.yaml
+++ b/compose.yaml
@@ -3,7 +3,7 @@ networks:
   vault-pki-exporter:
 services:
   vault:
-    image: vault:1.13.3
+    image: hashicorp/vault:1.14.1
     networks:
       - vault-pki-exporter
     ports:
@@ -38,3 +38,4 @@ services:
     depends_on:
       vault:
         condition: service_healthy
+    restart: always

--- a/pkg/vault-mon/pki.go
+++ b/pkg/vault-mon/pki.go
@@ -90,6 +90,11 @@ func (mon *PKIMon) Watch(interval time.Duration) {
 				if err != nil {
 					log.Errorln(err)
 				}
+
+				err = pki.loadCrl()
+				if err != nil {
+					log.Errorln(err)
+				}
 			}
 			mon.Loaded = true
 			time.Sleep(interval)
@@ -219,11 +224,6 @@ func (pki *PKI) loadCerts() error {
 
 				if cert.NotAfter.Unix() < time.Now().Unix() {
 					pki.expiredCertsCounter++
-				}
-
-				err = pki.loadCrl()
-				if err != nil {
-					log.Errorln(err)
 				}
 
 				if _, ok := pki.certs[cert.Subject.CommonName]; !ok && cert.NotAfter.Unix() > time.Now().Unix() {

--- a/pkg/vault-mon/prometheus.go
+++ b/pkg/vault-mon/prometheus.go
@@ -3,10 +3,11 @@ package vault_mon
 import (
 	"crypto/x509"
 	"fmt"
-	"log"
 	"net/http"
 	"strings"
 	"time"
+
+	log "github.com/aarnaud/vault-pki-exporter/pkg/logger"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -46,9 +47,11 @@ func PromWatchCerts(pkimon *PKIMon, interval time.Duration) {
 	}, labelNames)
 	certcount := promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "x509_cert_count",
+		Help: "Total count of non-expired certificates including revoked certificates",
 	}, []string{"source"})
 	expired_cert_count := promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "x509_expired_cert_count",
+		Help: "Total count of expired certificates including revoked certificates",
 	}, []string{"source"})
 	crl_expiry := promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "x509_crl_expiry",
@@ -74,15 +77,31 @@ func PromWatchCerts(pkimon *PKIMon, interval time.Duration) {
 			startTime := time.Now()
 			pkis := pkimon.GetPKIs()
 			now := time.Now()
+			revokedCerts := make(map[string]struct{})
+
 			for pkiname, pki := range pkis {
 				if crl := pki.GetCRL(); crl != nil {
 					crl_expiry.WithLabelValues(pkiname).Set(float64(crl.TBSCertList.NextUpdate.Sub(now).Seconds()))
 					crl_nextupdate.WithLabelValues(pkiname).Set(float64(crl.TBSCertList.NextUpdate.Unix()))
 					crl_length.WithLabelValues(pkiname).Set(float64(len(crl.TBSCertList.RevokedCertificates)))
 					crl_byte_size.WithLabelValues(pkiname).Set(float64(pki.crlRawSize))
+					// gather revoked certs from the CRL so we can exclude their metrics later
+					for _, revokedCert := range crl.TBSCertList.RevokedCertificates {
+						revokedCerts[revokedCert.SerialNumber.String()] = struct{}{}
+					}
 				}
 				for _, cert := range pki.GetCerts() {
 					certlabels := getLabelValues(pkiname, cert)
+					if _, isRevoked := revokedCerts[cert.SerialNumber.String()]; isRevoked {
+						// in case we have prior existing metrics, clear them for revoked certs
+						// seems fine to run in case the metrics don't exist or are already deleted too
+						expiry.DeleteLabelValues(certlabels...)
+						age.DeleteLabelValues(certlabels...)
+						startdate.DeleteLabelValues(certlabels...)
+						enddate.DeleteLabelValues(certlabels...)
+						continue
+					}
+
 					expiry.WithLabelValues(certlabels...).Set(float64(cert.NotAfter.Sub(now).Seconds()))
 					age.WithLabelValues(certlabels...).Set(float64(now.Sub(cert.NotBefore).Seconds()))
 					startdate.WithLabelValues(certlabels...).Set(float64(cert.NotBefore.Unix()))

--- a/tests.yml
+++ b/tests.yml
@@ -9,7 +9,7 @@ testcases:
   - name: docker compose up
     steps:
       - type: exec
-        script: docker compose up -d --wait
+        script: docker compose up --build -d --wait
   - name: vaultStatus
     steps:
       - name: vaultHealth
@@ -243,6 +243,63 @@ testcases:
         assertions:
           - result.statuscode ShouldEqual 200
 
+  - name: generateCertAndRevoke
+    steps:
+      - name: certrevokeme
+        type: http
+        method: POST
+        url: {{.vaultHost}}/v1/first-ca/issue/default
+        headers:
+          X-Vault-Token: {{.vaultToken}}
+          Content-Type: application/json
+        body: |
+          {
+            "common_name": "revokeme.first-ca.example.com"
+          }
+        assertions:
+          - result.statuscode ShouldEqual 200
+        vars:
+          serialNumber:
+            from: result.bodyjson.data.serial_number
+            regex: ".*" # not sure it's worth a proper regex
+            default: "0"
+      - name: configureCertificateURLs
+        type: http
+        method: POST
+        url: {{.vaultHost}}/v1/first-ca/config/urls
+        headers:
+          X-Vault-Token: {{.vaultToken}}
+          Content-Type: application/json
+        body: |
+          {
+            "issuing_certificates": "{{.vaultHost}}/v1/first-ca/ca",
+            "crl_distribution_points": "{{.vaultHost}}/v1/first-ca/crl"
+          }
+        assertions:
+          - result.statuscode ShouldEqual 200
+      - name: revokeCert
+        type: http
+        method: POST
+        url: {{.vaultHost}}/v1/first-ca/revoke
+        headers:
+          X-Vault-Token: {{.vaultToken}}
+          Content-Type: application/json
+        body: |
+          {
+            "serial_number": "{{.serialNumber}}"
+          }
+        assertions:
+          - result.statuscode ShouldEqual 200
+      - name: RotateCRL
+        type: http
+        method: GET
+        url: {{.vaultHost}}/v1/first-ca/crl/rotate
+        headers:
+          X-Vault-Token: {{.vaultToken}}
+          Content-Type: application/json
+        assertions:
+          - result.statuscode ShouldEqual 200
+
 
   - name: testMetrics
     steps:
@@ -265,6 +322,8 @@ testcases:
           - result.body ShouldContainSubstring common_name="first.second-ca.example.com"
           - result.body ShouldContainSubstring common_name="*.second-ca.example.com"
           - result.body ShouldContainSubstring common_name="alt.second-ca.example.com"
+          - result.body ShouldNotContainSubstring common_name="revokeme.first-ca.example.com"
+          - result.body ShouldContainSubstring x509_crl_length{source="first-ca/"} 1
 
   - name: docker compose down
     steps:

--- a/vault-setup.sh
+++ b/vault-setup.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+
+mkdir /vault/data
+# Start the Vault server in the background
+# vault server -config=/vault/config/config.hcl &
+vault server -dev -dev-listen-address="0.0.0.0:8200" &
+
+# Wait for Vault to start
+while ! vault status > /dev/null 2>&1; do
+    sleep 1
+done
+
+# Initialize and unseal Vault (if needed)
+# vault operator init ...
+# vault operator unseal ...
+
+# https://developer.hashicorp.com/vault/docs/secrets/pki/setup
+# Enable the PKI secrets engine
+vault secrets enable pki
+
+# Set the maximum lease TTL for the PKI secrets engine
+vault secrets tune -max-lease-ttl=87600h pki
+
+# Generate a root certificate (or use an existing one)
+# vault write -field=certificate pki/root/generate/internal \
+#     common_name="example.com" \
+#     ttl=87600h > CA_cert.crt
+
+ vault write pki/root/generate/internal \
+    common_name=my-website.com \
+    ttl=8760h
+
+vault write pki/config/urls \
+    issuing_certificates="http://127.0.0.1:8200/v1/pki/ca" \
+    crl_distribution_points="http://127.0.0.1:8200/v1/pki/crl"
+
+vault write pki/roles/example-dot-com \
+    allowed_domains=my-website.com \
+    allow_subdomains=true \
+    max_ttl=72h
+
+vault write pki/issue/example-dot-com \
+    common_name=www.my-website.com
+
+# Issue a certificate
+# vault write pki/issue/example-dot-com \
+#     common_name="www.example.com" \
+#     ttl="24h" > example_cert.crt
+
+# Your additional setup here...
+
+tail -f /dev/null

--- a/vault-setup.sh
+++ b/vault-setup.sh
@@ -1,5 +1,9 @@
 #!/bin/sh
 
+## NOTE
+## tests should be run with venom (tests.yml)
+## but this file is still useful for local development
+
 # Start the Vault server in the background
 # vault server -config=/vault/config/config.hcl &
 vault server -dev -dev-listen-address="0.0.0.0:8200" &


### PR DESCRIPTION
This change allows certificates to be revoked while vault-pki-exporter
is running and for the next metrics refreshed to drop expiration metrics
for the revoked certificate. Previously this only worked on exporter
restart.

In short, the idea now is to not skip revoked certificates during loadCerts() but instead check for them during the repeated `PromWatchCerts()` runs by examining the CRL we already load for CRL metrics.

Tests have been updated to support this along with quality-of-life changes to make testing this sort of interaction easier in the future.

cc @aarnaud for review :) 