### PR TITLE
avoid segfault when refreshing PKI certs

### DIFF
--- a/pkg/vault-mon/pki.go
+++ b/pkg/vault-mon/pki.go
@@ -115,6 +115,12 @@ func (pki *PKI) loadCrl() error {
 	if err != nil {
 		return err
 	}
+
+	// avoids a segfault
+	if secret == nil || secret.Data == nil {
+		return nil
+	}
+
 	secretCert := vault.SecretCertificate{}
 	err = mapstructure.Decode(secret.Data, &secretCert)
 	if err != nil {


### PR DESCRIPTION
This prevents a segfault when `pki.vault.Logical().Read` returns with no data
```
INFO[0000] mtls/test-intermediate/ loaded
INFO[0000] Refresh PKI certificate for mtls/test-intermediate/
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x30 pc=0x16e7034]
```