### PR TITLE
feat!: support CRLs with multiple issuers

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+export VAULT_ADDR="http://localhost:8200"
+export VAULT_TOKEN="thisisatokenvalue"

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ vault-pki-exporter
 
 # venom logs
 venom*log
+
+# envrc
+.envrc
+

--- a/README.md
+++ b/README.md
@@ -60,10 +60,10 @@ x509_cert,common_name=My\ PKI\ CA,country=CA,host=your.hostname.com,locality=Mon
 ```console
 # HELP x509_crl_expiry
 # TYPE x509_crl_expiry gauge
-x509_crl_expiry{source="pki-test/", issuer="CN=example.com"} 243687.999819847
+x509_crl_expiry{source="pki-test/", issuer="example.com"} 243687.999819847
 # HELP x509_crl_nextupdate
 # TYPE x509_crl_nextupdate gauge
-x509_crl_nextupdate{source="pki-test/", issuer="CN=example.com"} 1.573235993e+09
+x509_crl_nextupdate{source="pki-test/", issuer="example.com"} 1.573235993e+09
 # HELP x509_cert_age
 # TYPE x509_cert_age gauge
 x509_cert_age{common_name="My PKI CA",country="CA",locality="Montreal",organization="Example",organizational_unit="WebService",province="QC",serial="0e-50-38-4d-18-69-52-54-1d-71-31-49-1b-a8-06-c7-4f-23-64-26",source="pki-test/"} 15543.000180153

--- a/README.md
+++ b/README.md
@@ -89,3 +89,17 @@ level=error msg="failed to get certificate for pki/26:97:08:32:44:40:30:de:11:5z
 ```
 
 Your batch size is probably too high.
+
+## Contributing
+
+### Testing
+
+Venom is used for tests, run `sudo venom run tests.yml` to perform integration tests.
+
+Unit tests would also most likely be welcome for contribution with go native tests.
+
+### Local Builds
+
+Simply run the docker compose setup - `sudo docker compose up --build`.
+
+You can navigate to the Vault UI locally at `http://localhost:8200` and use the root token value of `thisisatokenvalue` to login, as Vault is running in dev mode. It'll setup some initial settings for you with `vault-setup.sh.`

--- a/README.md
+++ b/README.md
@@ -60,10 +60,10 @@ x509_cert,common_name=My\ PKI\ CA,country=CA,host=your.hostname.com,locality=Mon
 ```console
 # HELP x509_crl_expiry
 # TYPE x509_crl_expiry gauge
-x509_crl_expiry{source="pki-test/"} 243687.999819847
+x509_crl_expiry{source="pki-test/", issuer="CN=example.com"} 243687.999819847
 # HELP x509_crl_nextupdate
 # TYPE x509_crl_nextupdate gauge
-x509_crl_nextupdate{source="pki-test/"} 1.573235993e+09
+x509_crl_nextupdate{source="pki-test/", issuer="CN=example.com"} 1.573235993e+09
 # HELP x509_cert_age
 # TYPE x509_cert_age gauge
 x509_cert_age{common_name="My PKI CA",country="CA",locality="Montreal",organization="Example",organizational_unit="WebService",province="QC",serial="0e-50-38-4d-18-69-52-54-1d-71-31-49-1b-a8-06-c7-4f-23-64-26",source="pki-test/"} 15543.000180153

--- a/pkg/vault-mon/influx.go
+++ b/pkg/vault-mon/influx.go
@@ -2,12 +2,12 @@ package vault_mon
 
 import (
 	"crypto/x509"
-	"crypto/x509/pkix"
 	"fmt"
-	influx "github.com/influxdata/influxdb1-client"
 	"os"
 	"strings"
 	"time"
+
+	influx "github.com/influxdata/influxdb1-client"
 )
 
 var hostname string
@@ -72,7 +72,7 @@ func printCertificateInfluxPoint(pkiname string, cert *x509.Certificate) {
 	fmt.Println(point.MarshalString())
 }
 
-func printCrlInfluxPoint(pkiname string, crl *pkix.CertificateList) {
+func printCrlInfluxPoint(pkiname string, crl *x509.RevocationList) {
 	now := time.Now()
 	point := influx.Point{
 		Measurement: "x509_crl",
@@ -81,8 +81,8 @@ func printCrlInfluxPoint(pkiname string, crl *pkix.CertificateList) {
 			"source": pkiname,
 		},
 		Fields: map[string]interface{}{
-			"expiry":     int(crl.TBSCertList.NextUpdate.Sub(now).Seconds()),
-			"nextupdate": int(crl.TBSCertList.NextUpdate.Unix()),
+			"expiry":     int(crl.NextUpdate.Sub(now).Seconds()),
+			"nextupdate": int(crl.NextUpdate.Unix()),
 		},
 	}
 	fmt.Println(point.MarshalString())

--- a/pkg/vault-mon/influx.go
+++ b/pkg/vault-mon/influx.go
@@ -36,8 +36,10 @@ func InfluxWatchCerts(pkimon *PKIMon, interval time.Duration, loop bool) {
 
 func influxProcessData(pkimon *PKIMon) {
 	for pkiname, pki := range pkimon.GetPKIs() {
-		if crl := pki.GetCRL(); crl != nil {
-			printCrlInfluxPoint(pkiname, crl)
+		for _, crl := range pki.GetCRLs() {
+			if crl != nil {
+				printCrlInfluxPoint(pkiname, crl)
+			}
 		}
 		for _, cert := range pki.GetCerts() {
 			printCertificateInfluxPoint(pkiname, cert)

--- a/pkg/vault-mon/pki.go
+++ b/pkg/vault-mon/pki.go
@@ -179,15 +179,11 @@ func (pki *PKI) loadCrlForIssuer(issuerRef string) (*x509.RevocationList, error)
 		return nil, fmt.Errorf("no secret found for issuer %s", issuerRef)
 	}
 
-	log.Infof("Issuer: %s, Secret Data: %v", issuerRef, secret.Data)
-
 	crlData, ok := secret.Data["crl"].(string)
 	if !ok || crlData == "" {
 		log.Errorf("CRL data missing or invalid for issuer %s", issuerRef)
 		return nil, fmt.Errorf("crl data missing or invalid for issuer %s", issuerRef)
 	}
-
-	log.Infof("Issuer: %s, Raw CRL Data: %s", issuerRef, crlData)
 
 	block, _ := pem.Decode([]byte(crlData))
 	if block == nil {
@@ -203,7 +199,7 @@ func (pki *PKI) loadCrlForIssuer(issuerRef string) (*x509.RevocationList, error)
 		return nil, fmt.Errorf("error parsing CRL for issuer %s: %w", issuerRef, err)
 	}
 
-	log.Infof("Successfully loaded CRL for issuer %s", issuerRef)
+	log.Debugf("Successfully loaded CRL for issuer %s", issuerRef)
 
 	return crl, nil
 }

--- a/pkg/vault-mon/pki.go
+++ b/pkg/vault-mon/pki.go
@@ -20,7 +20,7 @@ import (
 type PKI struct {
 	path                string
 	certs               map[string]*x509.Certificate
-	crl                 *pkix.CertificateList
+	crls                map[string]*pkix.CertificateList
 	crlRawSize          int
 	expiredCertsCounter int
 	vault               *vaultapi.Client
@@ -111,31 +111,102 @@ func (mon *PKIMon) GetPKIs() map[string]*PKI {
 func (pki *PKI) loadCrl() error {
 	pki.crlmux.Lock()
 	defer pki.crlmux.Unlock()
-	secret, err := pki.vault.Logical().Read(fmt.Sprintf("%scert/crl", pki.path))
+
+	// List all issuers to get multiple CRLs per PKI engine
+	issuers, err := pki.listIssuers()
 	if err != nil {
 		return err
 	}
 
-	// avoids a segfault
-	if secret == nil || secret.Data == nil {
-		return nil
+	if pki.crls == nil {
+		pki.crls = make(map[string]*pkix.CertificateList)
+		log.Warningln("CRLs nil for issuers")
 	}
 
-	secretCert := vault.SecretCertificate{}
-	err = mapstructure.Decode(secret.Data, &secretCert)
-	if err != nil {
-		return err
+	for _, issuerRef := range issuers {
+		crl, err := pki.loadCrlForIssuer(issuerRef)
+		if err != nil || crl == nil {
+			log.Errorf("loadCrl() failed to load CRL for issuer %s, error: %v", issuerRef, err)
+		} else {
+			pki.crls[issuerRef] = crl
+		}
 	}
-	block, _ := pem.Decode([]byte([]byte(secretCert.Certificate)))
-	pki.crlRawSize = len([]byte(secretCert.Certificate))
-	crl, err := x509.ParseCRL(block.Bytes)
-	if err != nil {
-		log.Errorf("failed to load CRL for %s, error: %w", pki.path, err)
-		return err
-	}
-	pki.crl = crl
 
 	return nil
+}
+
+func (pki *PKI) listIssuers() ([]string, error) {
+	// Define the path where the issuers are listed in your Vault setup
+	// This path might be different based on your Vault configuration
+
+	// Make a read request to Vault
+	secret, err := pki.vault.Logical().List(fmt.Sprintf("%s/issuers", pki.path))
+	if err != nil {
+		return nil, fmt.Errorf("error listing issuers: %w", err)
+	}
+
+	if secret == nil || secret.Data == nil {
+		return []string{}, nil
+	}
+
+	// Extract the list of issuers from the response
+	// The key under which issuers Ware listed might vary, so adjust "keys" accordingly
+	issuerRefs, ok := secret.Data["keys"].([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("failed to parse issuer list")
+	}
+
+	// Convert issuer references to a slice of strings
+	issuers := make([]string, len(issuerRefs))
+	for i, ref := range issuerRefs {
+		issuer, ok := ref.(string)
+		if !ok {
+			return nil, fmt.Errorf("invalid issuer reference type")
+		}
+		issuers[i] = issuer
+	}
+
+	return issuers, nil
+}
+
+func (pki *PKI) loadCrlForIssuer(issuerRef string) (*pkix.CertificateList, error) {
+	secret, err := pki.vault.Logical().Read(fmt.Sprintf("/%s/issuer/%s/crl", pki.path, issuerRef))
+	if err != nil {
+		return nil, fmt.Errorf("error finding CRL at /%s/issuer/%s/crl: %w", pki.path, issuerRef, err)
+	}
+
+	if secret == nil {
+		log.Errorf("No secret found for issuer %s", issuerRef)
+		return nil, fmt.Errorf("no secret found for issuer %s", issuerRef)
+	}
+
+	log.Infof("Issuer: %s, Secret Data: %v", issuerRef, secret.Data)
+
+	crlData, ok := secret.Data["crl"].(string)
+	if !ok || crlData == "" {
+		log.Errorf("CRL data missing or invalid for issuer %s", issuerRef)
+		return nil, fmt.Errorf("crl data missing or invalid for issuer %s", issuerRef)
+	}
+
+	log.Infof("Issuer: %s, Raw CRL Data: %s", issuerRef, crlData)
+
+	block, _ := pem.Decode([]byte(crlData))
+	if block == nil {
+		log.Errorf("Failed to parse PEM block for issuer %s. Raw PEM data: %s", issuerRef, crlData)
+		return nil, fmt.Errorf("failed to parse PEM block for issuer %s", issuerRef)
+	}
+
+	pki.crlRawSize = len([]byte(crlData))
+
+	crl, err := x509.ParseCRL(block.Bytes)
+	if err != nil {
+		log.Errorf("Error parsing CRL for issuer %s: %v", issuerRef, err)
+		return nil, fmt.Errorf("error parsing CRL for issuer %s: %w", issuerRef, err)
+	}
+
+	log.Infof("Successfully loaded CRL for issuer %s", issuerRef)
+
+	return crl, nil
 }
 
 func (pki *PKI) loadCerts() error {
@@ -254,10 +325,10 @@ func (pki *PKI) clearCerts() {
 	pki.certsmux.Unlock()
 }
 
-func (pki *PKI) GetCRL() *pkix.CertificateList {
+func (pki *PKI) GetCRLs() map[string]*pkix.CertificateList {
 	pki.crlmux.Lock()
 	defer pki.crlmux.Unlock()
-	return pki.crl
+	return pki.crls
 }
 
 func (pki *PKI) GetCerts() map[string]*x509.Certificate {

--- a/pkg/vault-mon/pki.go
+++ b/pkg/vault-mon/pki.go
@@ -2,7 +2,6 @@ package vault_mon
 
 import (
 	"crypto/x509"
-	"crypto/x509/pkix"
 	"encoding/pem"
 	"fmt"
 	"sync"
@@ -20,7 +19,7 @@ import (
 type PKI struct {
 	path                string
 	certs               map[string]*x509.Certificate
-	crls                map[string]*pkix.CertificateList
+	crls                map[string]*x509.RevocationList
 	crlRawSize          int
 	expiredCertsCounter int
 	vault               *vaultapi.Client
@@ -119,8 +118,8 @@ func (pki *PKI) loadCrl() error {
 	}
 
 	if pki.crls == nil {
-		pki.crls = make(map[string]*pkix.CertificateList)
-		log.Warningln("CRLs nil for issuers")
+		pki.crls = make(map[string]*x509.RevocationList)
+		log.Warningln("init an empty certs list")
 	}
 
 	for _, issuerRef := range issuers {
@@ -169,7 +168,7 @@ func (pki *PKI) listIssuers() ([]string, error) {
 	return issuers, nil
 }
 
-func (pki *PKI) loadCrlForIssuer(issuerRef string) (*pkix.CertificateList, error) {
+func (pki *PKI) loadCrlForIssuer(issuerRef string) (*x509.RevocationList, error) {
 	secret, err := pki.vault.Logical().Read(fmt.Sprintf("/%s/issuer/%s/crl", pki.path, issuerRef))
 	if err != nil {
 		return nil, fmt.Errorf("error finding CRL at /%s/issuer/%s/crl: %w", pki.path, issuerRef, err)
@@ -198,7 +197,7 @@ func (pki *PKI) loadCrlForIssuer(issuerRef string) (*pkix.CertificateList, error
 
 	pki.crlRawSize = len([]byte(crlData))
 
-	crl, err := x509.ParseCRL(block.Bytes)
+	crl, err := x509.ParseRevocationList(block.Bytes)
 	if err != nil {
 		log.Errorf("Error parsing CRL for issuer %s: %v", issuerRef, err)
 		return nil, fmt.Errorf("error parsing CRL for issuer %s: %w", issuerRef, err)
@@ -325,7 +324,7 @@ func (pki *PKI) clearCerts() {
 	pki.certsmux.Unlock()
 }
 
-func (pki *PKI) GetCRLs() map[string]*pkix.CertificateList {
+func (pki *PKI) GetCRLs() map[string]*x509.RevocationList {
 	pki.crlmux.Lock()
 	defer pki.crlmux.Unlock()
 	return pki.crls

--- a/pkg/vault-mon/prometheus.go
+++ b/pkg/vault-mon/prometheus.go
@@ -75,7 +75,6 @@ func PromWatchCerts(pkimon *PKIMon, interval time.Duration) {
 			for pkiname, pki := range pkis {
 				for _, crl := range pki.GetCRLs() {
 					if crl != nil {
-						// issuer string is vanity, such as CN=my-website.com
 						issuer := crl.Issuer.CommonName
 
 						crl_expiry.WithLabelValues(pkiname, issuer).Set(float64(crl.NextUpdate.Sub(now).Seconds()))

--- a/pkg/vault-mon/prometheus.go
+++ b/pkg/vault-mon/prometheus.go
@@ -76,14 +76,14 @@ func PromWatchCerts(pkimon *PKIMon, interval time.Duration) {
 				for _, crl := range pki.GetCRLs() {
 					if crl != nil {
 						// issuer string is vanity, such as CN=my-website.com
-						issuer := crl.TBSCertList.Issuer.String()
+						issuer := crl.Issuer.String()
 
-						crl_expiry.WithLabelValues(pkiname, issuer).Set(float64(crl.TBSCertList.NextUpdate.Sub(now).Seconds()))
-						crl_nextupdate.WithLabelValues(pkiname, issuer).Set(float64(crl.TBSCertList.NextUpdate.Unix()))
-						crl_length.WithLabelValues(pkiname, issuer).Set(float64(len(crl.TBSCertList.RevokedCertificates)))
+						crl_expiry.WithLabelValues(pkiname, issuer).Set(float64(crl.NextUpdate.Sub(now).Seconds()))
+						crl_nextupdate.WithLabelValues(pkiname, issuer).Set(float64(crl.NextUpdate.Unix()))
+						crl_length.WithLabelValues(pkiname, issuer).Set(float64(len(crl.RevokedCertificates)))
 						crl_byte_size.WithLabelValues(pkiname, issuer).Set(float64(pki.crlRawSize))
 						// gather revoked certs from the CRL so we can exclude their metrics later
-						for _, revokedCert := range crl.TBSCertList.RevokedCertificates {
+						for _, revokedCert := range crl.RevokedCertificates {
 							revokedCerts[revokedCert.SerialNumber.String()] = struct{}{}
 						}
 					}

--- a/pkg/vault-mon/prometheus.go
+++ b/pkg/vault-mon/prometheus.go
@@ -76,7 +76,7 @@ func PromWatchCerts(pkimon *PKIMon, interval time.Duration) {
 				for _, crl := range pki.GetCRLs() {
 					if crl != nil {
 						// issuer string is vanity, such as CN=my-website.com
-						issuer := crl.Issuer.String()
+						issuer := crl.Issuer.CommonName
 
 						crl_expiry.WithLabelValues(pkiname, issuer).Set(float64(crl.NextUpdate.Sub(now).Seconds()))
 						crl_nextupdate.WithLabelValues(pkiname, issuer).Set(float64(crl.NextUpdate.Unix()))

--- a/pkg/vault-mon/prometheus.go
+++ b/pkg/vault-mon/prometheus.go
@@ -25,13 +25,6 @@ var labelNames = []string{
 	"locality",
 }
 
-type PromMetrics struct {
-	expiry    *prometheus.GaugeVec
-	age       *prometheus.GaugeVec
-	startdate *prometheus.GaugeVec
-	enddate   *prometheus.GaugeVec
-}
-
 func PromWatchCerts(pkimon *PKIMon, interval time.Duration) {
 	expiry := promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "x509_cert_expiry",

--- a/pkg/vault-mon/prometheus.go
+++ b/pkg/vault-mon/prometheus.go
@@ -55,18 +55,18 @@ func PromWatchCerts(pkimon *PKIMon, interval time.Duration) {
 	}, []string{"source"})
 	crl_expiry := promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "x509_crl_expiry",
-	}, []string{"source"})
+	}, []string{"source", "issuer"})
 	crl_nextupdate := promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "x509_crl_nextupdate",
-	}, []string{"source"})
+	}, []string{"source", "issuer"})
 	crl_byte_size := promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "x509_crl_byte_size",
 		Help: "Size of raw certificate revocation list pem stored in vault",
-	}, []string{"source"})
+	}, []string{"source", "issuer"})
 	crl_length := promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "x509_crl_length",
 		Help: "Length of certificate revocation list",
-	}, []string{"source"})
+	}, []string{"source", "issuer"})
 	promWatchCertsDuration := promauto.NewHistogram(prometheus.HistogramOpts{
 		Name:    "x509_watch_certs_duration_seconds",
 		Help:    "Duration of promWatchCerts execution",
@@ -80,14 +80,19 @@ func PromWatchCerts(pkimon *PKIMon, interval time.Duration) {
 			revokedCerts := make(map[string]struct{})
 
 			for pkiname, pki := range pkis {
-				if crl := pki.GetCRL(); crl != nil {
-					crl_expiry.WithLabelValues(pkiname).Set(float64(crl.TBSCertList.NextUpdate.Sub(now).Seconds()))
-					crl_nextupdate.WithLabelValues(pkiname).Set(float64(crl.TBSCertList.NextUpdate.Unix()))
-					crl_length.WithLabelValues(pkiname).Set(float64(len(crl.TBSCertList.RevokedCertificates)))
-					crl_byte_size.WithLabelValues(pkiname).Set(float64(pki.crlRawSize))
-					// gather revoked certs from the CRL so we can exclude their metrics later
-					for _, revokedCert := range crl.TBSCertList.RevokedCertificates {
-						revokedCerts[revokedCert.SerialNumber.String()] = struct{}{}
+				for _, crl := range pki.GetCRLs() {
+					if crl != nil {
+						// issuer string is vanity, such as CN=my-website.com
+						issuer := crl.TBSCertList.Issuer.String()
+
+						crl_expiry.WithLabelValues(pkiname, issuer).Set(float64(crl.TBSCertList.NextUpdate.Sub(now).Seconds()))
+						crl_nextupdate.WithLabelValues(pkiname, issuer).Set(float64(crl.TBSCertList.NextUpdate.Unix()))
+						crl_length.WithLabelValues(pkiname, issuer).Set(float64(len(crl.TBSCertList.RevokedCertificates)))
+						crl_byte_size.WithLabelValues(pkiname, issuer).Set(float64(pki.crlRawSize))
+						// gather revoked certs from the CRL so we can exclude their metrics later
+						for _, revokedCert := range crl.TBSCertList.RevokedCertificates {
+							revokedCerts[revokedCert.SerialNumber.String()] = struct{}{}
+						}
 					}
 				}
 				for _, cert := range pki.GetCerts() {

--- a/pkg/vault/client.go
+++ b/pkg/vault/client.go
@@ -116,11 +116,11 @@ func (vault *ClientWrapper) GetSecret(path string, fn secretCallback) error {
 					time.Sleep(time.Duration(secret.LeaseDuration) * time.Second)
 					secret, err = vault.Client.Logical().Read(path)
 					if err != nil {
-						log.Errorln("[vault]", err)
+						log.Error("[vault]", err)
 						continue
 					}
 					if secret == nil {
-						log.Errorln("[vault] secret not found : %s", path)
+						log.Errorf("[vault] secret not found : %s", path)
 						continue
 					}
 					fn(secret)

--- a/tests.yml
+++ b/tests.yml
@@ -323,7 +323,9 @@ testcases:
           - result.body ShouldContainSubstring common_name="*.second-ca.example.com"
           - result.body ShouldContainSubstring common_name="alt.second-ca.example.com"
           - result.body ShouldNotContainSubstring common_name="revokeme.first-ca.example.com"
-          - result.body ShouldContainSubstring x509_crl_length{source="first-ca/"} 1
+          # CRLs for each issuer
+          - result.body ShouldContainSubstring x509_crl_length{issuer="CN=First CA,OU=WebService,O=example,L=Montreal,ST=QC,C=CA",source="first-ca/"} 1
+          - result.body ShouldContainSubstring x509_crl_length{issuer="CN=Second CA,OU=VPN,O=example2,L=Montreal,ST=QC,C=CA",source="second-ca/"} 0
 
   - name: docker compose down
     steps:

--- a/tests.yml
+++ b/tests.yml
@@ -324,8 +324,8 @@ testcases:
           - result.body ShouldContainSubstring common_name="alt.second-ca.example.com"
           - result.body ShouldNotContainSubstring common_name="revokeme.first-ca.example.com"
           # CRLs for each issuer
-          - result.body ShouldContainSubstring x509_crl_length{issuer="CN=First CA,OU=WebService,O=example,L=Montreal,ST=QC,C=CA",source="first-ca/"} 1
-          - result.body ShouldContainSubstring x509_crl_length{issuer="CN=Second CA,OU=VPN,O=example2,L=Montreal,ST=QC,C=CA",source="second-ca/"} 0
+          - result.body ShouldContainSubstring x509_crl_length{issuer="my-website.com",source="pki/"} 1
+          - result.body ShouldContainSubstring x509_crl_length{issuer="mysecondwebsite.com",source="pki/"} 0
 
   - name: docker compose down
     steps:

--- a/vault-setup.sh
+++ b/vault-setup.sh
@@ -18,7 +18,7 @@ vault secrets enable pki
 
 vault secrets tune -max-lease-ttl=87600h pki
 
- vault write pki/root/generate/internal \
+vault write pki/root/generate/internal \
     common_name=my-website.com \
     ttl=8760h
 
@@ -44,5 +44,18 @@ vault write pki/issue/example-dot-com \
     common_name=www.my-website.com
 
 vault read pki/crl/rotate
+
+# make non-default second issuer
+# help test getting multiple CRLs
+ vault write pki/root/generate/internal \
+    common_name=mysecondwebsite.com \
+    ttl=8760h \
+    issuer_name=second
+
+vault write pki/roles/second-role \
+    allowed_domains=mysecondwebsite.com \
+    allow_subdomains=true \
+    max_ttl=72h \
+    issuer_ref=second
 
 tail -f /dev/null


### PR DESCRIPTION
Resolves: aarnaud#19

It is common practice to have multiple issuers and therefore CRLs in a
single Vault PKI secrets engine. Previously we'd only have metrics for
the default issuer in a PKI secrets engine. This refactors metrics
gathering to support CRL related metrics for all issuers in a secrets
engine.

This is marked as a breaking change due to the *addition* of an `issuer`
label to metrics like `x509_crl_length` but in most cases adding a new
label to existing metrics won't break alerting or recording rules
compared to removing a label. Regardless proper notice is given.

Old metric example:

```
x509_crl_nextupdate{source="pki/"} 1.730633058e+09
```

New metric example:

```
x509_crl_nextupdate{issuer="my-website.com",source="pki/"} 1.730633058e+09
x509_crl_nextupdate{issuer="mysecondwebsite.com",source="pki/"} 1.730633058e+09
```
---

Also adds contributing instructions and upgrades us from deprecated `pkix.CertificateList` to `x509.RevocationList`