### PR TITLE
chore: add verbose logs for certs found

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -28,6 +28,7 @@ services:
       - ./vault-pki-exporter
       - --fetch-interval=5s
       - --refresh-interval=5s
+      - --verbose=true
     networks:
       - vault-pki-exporter
     ports:


### PR DESCRIPTION
example output

```
vault-pki-exporter-1  | time="2024-11-13T19:19:01Z" level=info msg="processing batch of certs in loadCerts" batchsize=1
vault-pki-exporter-1  | time="2024-11-13T19:19:01Z" level=info msg="cert found" common_name=my-website.com country="[]" locality="[]" not_after="2025-11-13 19:17:11 +0000 UTC" not_before="2024-11-13 19:16:41 +0000 UTC" organization="[]" organizational_unit="[]" province="[]" serial_number=173416855333172776412784710165212082532478286322
vault-pki-exporter-1  | time="2024-11-13T19:19:01Z" level=info msg="cert found" common_name=www.my-website.com country="[]" locality="[]" not_after="2024-11-16 19:17:12 +0000 UTC" not_before="2024-11-13 19:16:42 +0000 UTC" organization="[]" organizational_unit="[]" province="[]" serial_number=529726630108698805212027385972163988162531905986
vault-pki-exporter-1  | time="2024-11-13T19:19:01Z" level=info msg="cert found" common_name=www.revokme.my-website.com country="[]" locality="[]" not_after="2024-11-16 19:17:12 +0000 UTC" not_before="2024-11-13 19:16:42 +0000 UTC" organization="[]" organizational_unit="[]" province="[]" serial_number=575798736834614521163199043618936418300586073698
```