### PR TITLE
feat: rate limiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ Flags:
       --refresh-interval duration   How many sec between metrics update (default 1m0s)
       --batch-size-percent          How large of a batch of certificates to get data for at once, supports floats (e.g 0.0 - 100.0) (default 1)
       --log-level                   Set log level (options: info, warn, error, debug)
+      --request-limit float         Token-bucket limiter for number of requests per second to Vault when fetching certs (0 = disabled)
+      --request-limit-burst int     Token-bucket burst limit for number of requests per second to Vault when fetching certs (0 = match 'request-limit' value)
   -v, --verbose                     (deprecated) Enable verbose logging. Defaults to debug level logging
 
 Use " [command] --help" for more information about a command.

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ x509_cert_startdate{common_name="My PKI CA",country="CA",locality="Montreal",org
 
 ## Batch Size
 
-Vault PKI Exporter supports a `--batch-size-percent` flag to batch many requests for individual certificate metrics at once.
+Vault PKI Exporter supports a `--batch-size-percent` flag to batch many requests for individual certificate metrics at once. Each active batch will create a goroutine.
 
 If you are getting many log messages such as:
 
@@ -92,6 +92,10 @@ level=error msg="failed to get certificate for pki/26:97:08:32:44:40:30:de:11:5z
 ```
 
 Your batch size is probably too high.
+
+## Rate Limiting
+
+Rate limiting flags are also added for large Vault installations. These rate limits apply to all batches with a global, shared limit between batches. This is to prevent overloading Vault with many API calls. You may want to set your `--request-limit-burst` roughly equal to `--request-limit` so the token bucket will begin with as many tokens as your limit uses. This is measured in Vault API calls per second.
 
 ## Certificate Selection
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -73,6 +73,16 @@ func init() {
 	if err := viper.BindPFlag("batch_size_percent", flags.Lookup("batch-size-percent")); err != nil {
 		log.Fatal("Could not bind batch-size-percent flag:", err)
 	}
+
+	flags.Float64("request-limit", 0.0, "Token-bucket limiter for number of requests per second to Vault when fetching certs (0 = disabled)")
+	if err := viper.BindPFlag("request_limit", flags.Lookup("request-limit")); err != nil {
+		log.Fatal(err)
+	}
+
+	flags.Int("request-limit-burst", 0, "Token-bucket burst limit for number of requests per second to Vault when fetching certs (0 = match 'request-limit' value)")
+	if err := viper.BindPFlag("request_limit_burst", flags.Lookup("request-limit-burst")); err != nil {
+		log.Fatal(err)
+	}
 }
 
 func main() {
@@ -87,7 +97,7 @@ func main() {
 	}
 
 	// note mix of underscores and dashes
-	slog.Info("CLI flag values", "fetch-interval", viper.GetDuration("fetch_interval"), "refresh-interval", viper.GetDuration("refresh_interval"), "batch-size-percent", viper.GetFloat64("batch_size_percent") )
+	slog.Info("CLI flag values", "fetch-interval", viper.GetDuration("fetch_interval"), "refresh-interval", viper.GetDuration("refresh_interval"), "batch-size-percent", viper.GetFloat64("batch_size_percent"), "request-limit", viper.GetFloat64("request_limit"), "request-limit-burst", viper.GetInt("request_limit_burst") )
 
 	err := cli.Execute()
 	if err != nil {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -76,12 +76,12 @@ func init() {
 
 	flags.Float64("request-limit", 0.0, "Token-bucket limiter for number of requests per second to Vault when fetching certs (0 = disabled)")
 	if err := viper.BindPFlag("request_limit", flags.Lookup("request-limit")); err != nil {
-		log.Fatal(err)
+		logger.SlogFatal("Could not bind request-limit flag", "error", err)
 	}
 
 	flags.Int("request-limit-burst", 0, "Token-bucket burst limit for number of requests per second to Vault when fetching certs (0 = match 'request-limit' value)")
 	if err := viper.BindPFlag("request_limit_burst", flags.Lookup("request-limit-burst")); err != nil {
-		log.Fatal(err)
+		logger.SlogFatal("Could not bind request-limit-burst flag", "error", err)
 	}
 }
 
@@ -96,7 +96,7 @@ func main() {
 	}
 
 	// note mix of underscores and dashes
-	slog.Info("CLI flag values", "fetch-interval", viper.GetDuration("fetch_interval"), "refresh-interval", viper.GetDuration("refresh_interval"), "batch-size-percent", viper.GetFloat64("batch_size_percent"), "request-limit", viper.GetFloat64("request_limit"), "request-limit-burst", viper.GetInt("request_limit_burst") )
+	slog.Info("CLI flag values", "fetch-interval", viper.GetDuration("fetch_interval"), "refresh-interval", viper.GetDuration("refresh_interval"), "batch-size-percent", viper.GetFloat64("batch_size_percent"), "request-limit", viper.GetFloat64("request_limit"), "request-limit-burst", viper.GetInt("request_limit_burst"))
 
 	err := cli.Execute()
 	if err != nil {

--- a/compose.yaml
+++ b/compose.yaml
@@ -29,9 +29,9 @@ services:
       - --fetch-interval=5s
       - --refresh-interval=5s
       - --log-level=debug
-      # 5 requests per second
+      # 20 requests per second
       - --request-limit=20
-      # burst of 75 tokens
+      # burst of 20 tokens
       - --request-limit-burst=20
     networks:
       - vault-pki-exporter

--- a/compose.yaml
+++ b/compose.yaml
@@ -29,6 +29,10 @@ services:
       - --fetch-interval=5s
       - --refresh-interval=5s
       - --log-level=debug
+      # 5 requests per second
+      - --request-limit=5
+      # burst of 75 tokens
+      - --request-limit-burst=75
     networks:
       - vault-pki-exporter
     ports:

--- a/compose.yaml
+++ b/compose.yaml
@@ -30,9 +30,9 @@ services:
       - --refresh-interval=5s
       - --log-level=debug
       # 5 requests per second
-      - --request-limit=5
+      - --request-limit=20
       # burst of 75 tokens
-      - --request-limit-burst=75
+      - --request-limit-burst=20
     networks:
       - vault-pki-exporter
     ports:

--- a/pkg/vault-mon/influx.go
+++ b/pkg/vault-mon/influx.go
@@ -3,6 +3,7 @@ package vault_mon
 import (
 	"crypto/x509"
 	"fmt"
+	"log/slog"
 	"os"
 	"strings"
 	"time"
@@ -21,6 +22,7 @@ func InfluxWatchCerts(pkimon *PKIMon, interval time.Duration, loop bool) {
 		go func() {
 			for {
 				influxProcessData(pkimon)
+				slog.Info("Sleeping after processing influx data", "time", interval)
 				time.Sleep(interval)
 			}
 		}()

--- a/pkg/vault-mon/influx.go
+++ b/pkg/vault-mon/influx.go
@@ -22,7 +22,7 @@ func InfluxWatchCerts(pkimon *PKIMon, interval time.Duration, loop bool) {
 		go func() {
 			for {
 				influxProcessData(pkimon)
-				slog.Info("Sleeping after processing influx data", "time", interval)
+				slog.Info("Sleeping after processing influx data", "interval", interval)
 				time.Sleep(interval)
 			}
 		}()

--- a/pkg/vault-mon/pki.go
+++ b/pkg/vault-mon/pki.go
@@ -104,6 +104,7 @@ func (mon *PKIMon) Watch(interval time.Duration) {
 				}
 			}
 			mon.Loaded = true
+			slog.Info("Sleeping after refreshing PKI certs", "time", interval)
 			time.Sleep(interval)
 		}
 	}()

--- a/pkg/vault-mon/pki.go
+++ b/pkg/vault-mon/pki.go
@@ -361,7 +361,9 @@ func (pki *PKI) GetCRLs() map[string]*x509.RevocationList {
 }
 
 func (pki *PKI) GetCerts() map[string]map[string]*x509.Certificate {
+	// Unlock the mutex, return the certs, then re-lock it
+	pki.certsmux.Unlock()
+	certs := pki.certs
 	pki.certsmux.Lock()
-	defer pki.certsmux.Unlock()
-	return pki.certs
+	return certs
 }

--- a/pkg/vault-mon/pki.go
+++ b/pkg/vault-mon/pki.go
@@ -104,7 +104,7 @@ func (mon *PKIMon) Watch(interval time.Duration) {
 				}
 			}
 			mon.Loaded = true
-			slog.Info("Sleeping after refreshing PKI certs", "time", interval)
+			slog.Info("Sleeping after refreshing PKI certs", "interval", interval)
 			time.Sleep(interval)
 		}
 	}()

--- a/pkg/vault-mon/pki.go
+++ b/pkg/vault-mon/pki.go
@@ -377,9 +377,7 @@ func (pki *PKI) GetCRLs() map[string]*x509.RevocationList {
 }
 
 func (pki *PKI) GetCerts() map[string]map[string]*x509.Certificate {
-	// Unlock the mutex, return the certs, then re-lock it
-	pki.certsmux.Unlock()
-	certs := pki.certs
 	pki.certsmux.Lock()
-	return certs
+	defer pki.certsmux.Unlock()
+	return pki.certs
 }

--- a/pkg/vault-mon/pki.go
+++ b/pkg/vault-mon/pki.go
@@ -271,7 +271,7 @@ func (pki *PKI) loadCerts() error {
 		batchKeys := serialsList.Keys[i:end]
 
 		var wg sync.WaitGroup
-		slog.Info("Processing batch of certs", "pki", pki.path, "batchsize", len(batchKeys))
+		slog.Info("Processing batch of certs", "pki", pki.path, "batchsize", len(batchKeys), "total_size", len(serialsList.Keys))
 
 		// add a mutex for protecting concurrent access to the certs map
 		var certsMux sync.Mutex

--- a/pkg/vault-mon/prometheus.go
+++ b/pkg/vault-mon/prometheus.go
@@ -128,7 +128,7 @@ func PromWatchCerts(pkimon *PKIMon, interval time.Duration) {
 
 				duration := time.Since(startTime).Seconds()
 				promWatchCertsDuration.Observe(duration)
-				slog.Info("PromWatchCerts loop completed", "duration_seconds", duration, "pkis_processed", len(pkis))
+				slog.Info("Sleeping after PromWatchCerts loop completed", "duration_seconds", duration, "pkis_processed", len(pkis), "time", interval)
 				time.Sleep(interval)
 			}
 		}

--- a/pkg/vault-mon/prometheus.go
+++ b/pkg/vault-mon/prometheus.go
@@ -128,7 +128,7 @@ func PromWatchCerts(pkimon *PKIMon, interval time.Duration) {
 
 				duration := time.Since(startTime).Seconds()
 				promWatchCertsDuration.Observe(duration)
-				slog.Info("Sleeping after PromWatchCerts loop completed", "duration_seconds", duration, "pkis_processed", len(pkis), "time", interval)
+				slog.Info("Sleeping after PromWatchCerts loop completed", "duration_seconds", duration, "pkis_processed", len(pkis), "interval", interval)
 				time.Sleep(interval)
 			}
 		}

--- a/pkg/vault/client.go
+++ b/pkg/vault/client.go
@@ -115,6 +115,7 @@ func (vault *ClientWrapper) GetSecret(path string, fn secretCallback) error {
 		if secret.LeaseDuration > 0 {
 			go func() {
 				for {
+					slog.Info("Sleeping before refreshing vault", "time", time.Duration(secret.LeaseDuration))
 					time.Sleep(time.Duration(secret.LeaseDuration) * time.Second)
 					secret, err = vault.Client.Logical().Read(path)
 					if err != nil {
@@ -175,6 +176,7 @@ func watch_renewer_vault(renewer *vaultapi.Renewer) {
 	go func() {
 		for {
 			// Prevent loop when secret wasn't renewed before expiration
+			slog.Info("Waiting before calling another renew", "time", time.Second)
 			time.Sleep(time.Second)
 			renewer.Renew()
 		}

--- a/pkg/vault/client.go
+++ b/pkg/vault/client.go
@@ -115,7 +115,7 @@ func (vault *ClientWrapper) GetSecret(path string, fn secretCallback) error {
 		if secret.LeaseDuration > 0 {
 			go func() {
 				for {
-					slog.Info("Sleeping before refreshing vault", "time", time.Duration(secret.LeaseDuration))
+					slog.Info("Sleeping before refreshing vault", "interval", time.Duration(secret.LeaseDuration))
 					time.Sleep(time.Duration(secret.LeaseDuration) * time.Second)
 					secret, err = vault.Client.Logical().Read(path)
 					if err != nil {
@@ -176,7 +176,7 @@ func watch_renewer_vault(renewer *vaultapi.Renewer) {
 	go func() {
 		for {
 			// Prevent loop when secret wasn't renewed before expiration
-			slog.Info("Waiting before calling another renew", "time", time.Second)
+			slog.Info("Waiting before calling another renew", "interval", time.Second)
 			time.Sleep(time.Second)
 			renewer.Renew()
 		}


### PR DESCRIPTION
Our Vault installation is large and we ended up causing problems requesting so much cert data at once. Rate limiting will apply globally to the batches and adds more configuration options to handle large PKI engines. Off by default!

Implement's a commit from @wbh1. Copied message:

"In instances where Vault has a bunch of certificates, you can
essentially DoS Vault with all your requests. Instead of spamming all of
the requests as fast as you can, this allows you to throttle how many
requests per second you send to Vault by using a simple token-bucket
rate limiter.

The limiter is off by default, so this does not change existing default
behavior."

linode-obs@1e45b57

Co-authored-by: Will Hegedus <will@wbhegedus.me>