### PR TITLE
fix: reduce PKI metrics info logging

### DIFF
--- a/pkg/vault-mon/prometheus.go
+++ b/pkg/vault-mon/prometheus.go
@@ -125,12 +125,10 @@ func PromWatchCerts(pkimon *PKIMon, interval time.Duration) {
 					certcount.WithLabelValues(pkiname).Set(float64(len(pki.certs)))
 					expired_cert_count.WithLabelValues(pkiname).Set(float64(pki.expiredCertsCounter))
 
-					slog.Info("PKI metrics updated", "pki", pkiname, "total_certs", len(pki.certs), "expired_certs", pki.expiredCertsCounter)
 				}
-
 				duration := time.Since(startTime).Seconds()
 				promWatchCertsDuration.Observe(duration)
-				slog.Info("Sleeping after PromWatchCerts loop completed", "duration_seconds", duration, "pkis_processed", len(pkis), "interval", interval)
+				slog.Info("PKI Prometheus metrics updated, sleeping", "pki", pkiname, "total_certs", len(pki.certs), "expired_certs", pki.expiredCertsCounter, "duration_seconds", duration, "interval", interval)
 				time.Sleep(interval)
 			}
 		}


### PR DESCRIPTION
A mistake in where the PKI Metrics Updated log line was placed results in that log line occuring for every single cert which is too much logging for Info logs. Consolidates it to one log line at the end of each PKI run that updates Prometheus metrics