### PR TITLE
feat: cli help usage

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -83,12 +83,26 @@ func init() {
 	if err := viper.BindPFlag("request_limit_burst", flags.Lookup("request-limit-burst")); err != nil {
 		logger.SlogFatal("Could not bind request-limit-burst flag", "error", err)
 	}
+
+	flags.BoolP("help", "h", false, "Show help message")
+	if err := viper.BindPFlag("help", flags.Lookup("help")); err != nil {
+		logger.SlogFatal("Could not bind help flag", "error", err)
+	}
+
 }
 
 func main() {
 	err := cli.ParseFlags(os.Args[1:])
 	if err != nil {
 		logger.SlogFatal("CLI parsing failed", "error", err)
+	}
+
+	if viper.GetBool("help") {
+		err := cli.Usage()
+		if err != nil {
+			logger.SlogFatal("Getting CLI usage failed", "error", err)
+		}
+		os.Exit(0)
 	}
 
 	// preserve deprecated verbose flag


### PR DESCRIPTION
adds a help flag

```console
❯ ./vault_pki_exporter -h                                                                                          vault-pki-exporter/git/master !
Usage:
   [flags]
   [command]

Available Commands:
  version     Print the version.

Flags:
      --batch-size-percent float    loadCerts batch size percentage, supports floats (e.g 0.0 - 100.0) (default 1)
      --fetch-interval duration     How many sec between fetch certs on vault (default 1m0s)
  -h, --help                        Show help message
      --influx                      Enable InfluxDB Line Protocol
      --log-level string            Set log level (options: info, warn, error, debug) (default "info")
      --port int                    Prometheus exporter HTTP port (default 9333)
      --prometheus                  Enable prometheus exporter, default if nothing else
      --refresh-interval duration   How many sec between metrics update (default 1m0s)
      --request-limit float         Token-bucket limiter for number of requests per second to Vault when fetching certs (0 = disabled)
      --request-limit-burst int     Token-bucket burst limit for number of requests per second to Vault when fetching certs (0 = match 'request-limit' value)
  -v, --verbose                     Enable verbose

Use " [command] --help" for more information about a command.
```